### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ There is no installer. Just download the executable and run it either by double-
    - **Start with Windows** - Automatically start RetroBat Runner at login.
    - **Command before launch** - Launch another program before RetroBat starts. ⚠️ See note below
    - **Command after exit** - Launch another program after RetroBat closes. ⚠️ See note below
+   - **Open EmulationStation events** - Open the EmulationStation events folder. ⚠️ See note below
    - **Visit RetroBat Runner website** - Open the GitHub page in your browser.
    - **About RetroBat Runner** - View version info and credits.
 
@@ -119,6 +120,7 @@ RetroBat Runner currently meets the needs it was designed for, and no major new 
 
 ### 1.4.1 (xx December 2025)
 - "Command after exit" no longer runs when using EmulationStation’s "shutdown" or "restart" options. Windows does not allow enough time for commands to run reliably; use EmulationStation’s own built-in event system for scripts triggered on shutdown or restart.
+- Added new menu item "Open EmulationStation events" which opens Windows Explorer with the location to place scripts/shortcuts/programs for triggering.
 - Updated documentation to explain how to use EmulationStation's event system.
 - Fixed a bug where video intros 5 seconds or longer would incorrectly trigger a pop-up claiming that EmulationStation did not appear to be launching.
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ RetroBat Runner currently meets the needs it was designed for, and no major new 
 - Added new menu item "Open RetroBat Runner events" and moved "Command before launch" and "Command after exit" into a sub-menu.
 - Updated the copy on the pop-up for RetroBat Runner events to make clear that these will only run if EmulationStation was launched by RetroBat Runner.
 - Updated documentation to explain how to use EmulationStation's event system.
-- Fixed a bug where video intros 5 seconds or longer would incorrectly trigger a pop-up claiming that EmulationStation did not appear to be launching.
+- Fixed a bug where video intros over 5 second long would incorrectly trigger a pop-up claiming that EmulationStation did not appear to be launching.
+- Fixed a bug where buffered controller presses could mean the video intro is inadvertently skipped before it starts.
 
 ### 1.4.0 (20th November 2025)
 - Removed automatic preference for `RetroBat-new.exe` because RetroBat v7.5.1 no longer uses this executable and doesn’t delete it during upgrades, so RetroBat Runner can’t rely on it being the correct one.

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ RetroBat Runner currently meets the needs it was designed for, and no major new 
 
 ## 🕰️ Version history
 
-### 1.5.0 (xx December 2025)
-- "Command after exit" no longer runs when using EmulationStation’s "shutdown" or "restart" options. Windows does not allow enough time for commands to run reliably; use EmulationStation’s own built-in event system for scripts triggered on shutdown or restart.
+### 1.5.0 (16 December 2025)
+- "Command after exit" no longer runs when using EmulationStation's "shutdown" or "restart" options. Windows does not allow enough time for commands to run reliably; use EmulationStation’s own built-in event system for scripts triggered on shutdown or restart.
 - Added new menu item "Open EmulationStation events" which opens Windows Explorer with the location to place scripts/shortcuts/programs for triggering.
 - Added new menu item "Open RetroBat Runner events" and moved "Command before launch" and "Command after exit" into a sub-menu.
 - Updated the copy on the pop-up for RetroBat Runner events to make clear that these will only run if EmulationStation was launched by RetroBat Runner.
@@ -129,6 +129,7 @@ RetroBat Runner currently meets the needs it was designed for, and no major new 
 - Fixed a bug where buffered controller presses could mean the video intro is inadvertently skipped before it starts.
 - Applied a workaround to correct XInput controllers occasionally being treated as DirectInput, which would stop vibration from working.
 - Tray menu cleaned up and reordered.
+- Some code tidied up (mainly function naming and global declarations)
 
 ### 1.4.0 (20th November 2025)
 - Removed automatic preference for `RetroBat-new.exe` because RetroBat v7.5.1 no longer uses this executable and doesn’t delete it during upgrades, so RetroBat Runner can’t rely on it being the correct one.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ RetroBat Runner currently meets the needs it was designed for, and no major new 
 
 ## 🕰️ Version history
 
-### 1.4.1 (xx December 2025)
+### 1.5.0 (xx December 2025)
 - "Command after exit" no longer runs when using EmulationStation’s "shutdown" or "restart" options. Windows does not allow enough time for commands to run reliably; use EmulationStation’s own built-in event system for scripts triggered on shutdown or restart.
 - Added new menu item "Open EmulationStation events" which opens Windows Explorer with the location to place scripts/shortcuts/programs for triggering.
 - Added new menu item "Open RetroBat Runner events" and moved "Command before launch" and "Command after exit" into a sub-menu.
@@ -127,6 +127,8 @@ RetroBat Runner currently meets the needs it was designed for, and no major new 
 - Updated documentation to explain how to use EmulationStation's event system.
 - Fixed a bug where video intros over 5 second long would incorrectly trigger a pop-up claiming that EmulationStation did not appear to be launching.
 - Fixed a bug where buffered controller presses could mean the video intro is inadvertently skipped before it starts.
+- Applied a workaround to correct XInput controllers occasionally being treated as DirectInput, which would stop vibration from working.
+- Tray menu cleaned up and reordered.
 
 ### 1.4.0 (20th November 2025)
 - Removed automatic preference for `RetroBat-new.exe` because RetroBat v7.5.1 no longer uses this executable and doesn’t delete it during upgrades, so RetroBat Runner can’t rely on it being the correct one.

--- a/README.md
+++ b/README.md
@@ -44,13 +44,38 @@ There is no installer. Just download the executable and run it either by double-
    - Triggering the combination while RetroBat is running does nothing.
 5. To configure options, right-click the system tray icon to access:
    - **Start with Windows** - Automatically start RetroBat Runner at login.
-   - **Command before launch** - Launch another program before RetroBat starts.
-   - **Command after exit** - Launch another program after RetroBat closes.
+   - **Command before launch** - Launch another program before RetroBat starts. ⚠️ See note below
+   - **Command after exit** - Launch another program after RetroBat closes. ⚠️ See note below
    - **Visit RetroBat Runner website** - Open the GitHub page in your browser.
    - **About RetroBat Runner** - View version info and credits.
 
 > [!TIP]
 > The same controller must be used to press both buttons. You cannot press **SELECT/BACK** on one controller and **START** on a different controller.
+
+### Executing commands before and after launch or exit
+
+EmulationStation includes its own event system. You can place programs, shortcuts or scripts in specific folders inside your RetroBat installation and EmulationStation will run whatever is inside these folders whenever the matching event occurs. These events run every time EmulationStation starts, stops or changes state. It does not matter whether you opened RetroBat directly or launched it through RetroBat Runner.
+
+Use RetroBat Runner’s "command before launch" and "command after exit" when you want a script to run at the moment RetroBat is launched or closed **but only when it was started through the controller button combination.** These commands do not run if you open RetroBat in any other way.
+
+Assuming you install to the default location, then the event folders are inside `C:\RetroBat\emulationstation\.emulationstation\scripts`:
+
+| Subfolder name     | When it runs                                |
+| :----------------- | :------------------------------------------ |
+| `game-end`         | When a game ends                            |
+| `game-start`       | When a game starts                          |
+| `quit`             | When EmulationStation quits normally        |
+| `reboot`           | When EmulationStation reboots the system    |
+| `shutdown`         | When EmulationStation shuts down the system |
+| `sleep`            | When the system enters sleep                |
+| `start`            | When EmulationStation starts                |
+| `update-gamelists` | When gamelists are updated                  |
+| `wake`             | When the system wakes from sleep            |
+
+>[!NOTE]
+>- Scripts here run independently of RetroBat Runner.
+>- RetroBat Runner settings run only when RetroBat is launched via the controller combination.
+>- Avoid putting the same script in both places unless you want it to fire twice.
 
 ## ⚙️ Installation
 
@@ -91,6 +116,11 @@ RetroBat Runner currently meets the needs it was designed for, and no major new 
 - RetroBat is copyright &copy; Adrien Chalard and the RetroBat Team. For more details visit the [website](https://www.retrobat.org/) or the [GitHub repository](https://github.com/RetroBat-Official). 
 
 ## 🕰️ Version history
+
+### 1.4.1 (xx December 2025)
+- "Command after exit" no longer runs when using EmulationStation’s "shutdown" or "restart" options. Windows does not allow enough time for commands to run reliably; use EmulationStation’s own built-in event system for scripts triggered on shutdown or restart.
+- Updated documentation to explain how to use EmulationStation's event system.
+- Fixed a bug where video intros 5 seconds or longer would incorrectly trigger a pop-up claiming that EmulationStation did not appear to be launching.
 
 ### 1.4.0 (20th November 2025)
 - Removed automatic preference for `RetroBat-new.exe` because RetroBat v7.5.1 no longer uses this executable and doesn’t delete it during upgrades, so RetroBat Runner can’t rely on it being the correct one.

--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ There is no installer. Just download the executable and run it either by double-
    - Triggering the combination while RetroBat is running does nothing.
 5. To configure options, right-click the system tray icon to access:
    - **Start with Windows** - Automatically start RetroBat Runner at login.
-   - **Command before launch** - Launch another program before RetroBat starts. ⚠️ See note below
-   - **Command after exit** - Launch another program after RetroBat closes. ⚠️ See note below
-   - **Open EmulationStation events** - Open the EmulationStation events folder. ⚠️ See note below
+   - **RetroBat Runner events** - Opens a submenu for you to configure triggers on events.
+     - **Command before launch** - Launch another program before RetroBat starts. ⚠️ See [this section](#executing-commands-before-and-after-launch-or-exit) below
+     - **Command after exit** - Launch another program after RetroBat closes. ⚠️ See [this section](#executing-commands-before-and-after-launch-or-exit) below
+   - **EmulationStation events** - Open the EmulationStation events folder. ⚠️ See [this section](#executing-commands-before-and-after-launch-or-exit) below
    - **Visit RetroBat Runner website** - Open the GitHub page in your browser.
    - **About RetroBat Runner** - View version info and credits.
 
@@ -121,6 +122,8 @@ RetroBat Runner currently meets the needs it was designed for, and no major new 
 ### 1.4.1 (xx December 2025)
 - "Command after exit" no longer runs when using EmulationStation’s "shutdown" or "restart" options. Windows does not allow enough time for commands to run reliably; use EmulationStation’s own built-in event system for scripts triggered on shutdown or restart.
 - Added new menu item "Open EmulationStation events" which opens Windows Explorer with the location to place scripts/shortcuts/programs for triggering.
+- Added new menu item "Open RetroBat Runner events" and moved "Command before launch" and "Command after exit" into a sub-menu.
+- Updated the copy on the pop-up for RetroBat Runner events to make clear that these will only run if EmulationStation was launched by RetroBat Runner.
 - Updated documentation to explain how to use EmulationStation's event system.
 - Fixed a bug where video intros 5 seconds or longer would incorrectly trigger a pop-up claiming that EmulationStation did not appear to be launching.
 

--- a/RetroBat_Runner.ahk
+++ b/RetroBat_Runner.ahk
@@ -4,7 +4,7 @@
 #Warn
 
 ;
-; RetroBat Runner v1.5.0 (16 December 2025)
+; RetroBat Runner v1.5.0 (16th December 2025)
 ; Automatically launch RetroBat when a specific button combination is
 ; pressed on any connected controller
 ; https://github.com/silver76/retrobat-runner/
@@ -146,7 +146,7 @@ Run_Execute_After() {
 		cmd := RegRead("HKEY_CURRENT_USER\Software\RetroBat Runner", "ExecuteAfter")
 		if (cmd) {
 			Logger("Check_ES_Status", "Executing after command: " cmd)
-			Run(cmd, , , &pid)  ; Don't wait for this to finish
+			Run(cmd)  ; Don't wait for this to finish
 		}
 	}
 }
@@ -239,7 +239,7 @@ Detect_Second_Input(controllerID, firstButton, inputMode) {
 }
 
 ; Wait_For_Release
-; Waits for the specific controller to no longer be pressing any buttons
+; Waits for the specific controller (defined by controllerID) to be no longer pressing any buttons
 Wait_For_Release(controllerID, inputMode) {
     Logger("Wait_For_Release", "Entering function")
 


### PR DESCRIPTION
- "Command after exit" no longer runs when using EmulationStation's "shutdown" or "restart" options. Windows does not allow enough time for commands to run reliably; use EmulationStation’s own built-in event system for scripts triggered on shutdown or restart.
- Added new menu item "Open EmulationStation events" which opens Windows Explorer with the location to place scripts/shortcuts/programs for triggering.
- Added new menu item "Open RetroBat Runner events" and moved "Command before launch" and "Command after exit" into a sub-menu.
- Updated the copy on the pop-up for RetroBat Runner events to make clear that these will only run if EmulationStation was launched by RetroBat Runner.
- Updated documentation to explain how to use EmulationStation's event system.
- Fixed a bug where video intros over 5 second long would incorrectly trigger a pop-up claiming that EmulationStation did not appear to be launching.
- Fixed a bug where buffered controller presses could mean the video intro is inadvertently skipped before it starts.
- Applied a workaround to correct XInput controllers occasionally being treated as DirectInput, which would stop vibration from working.
- Tray menu cleaned up and reordered.
- Some code tidied up (mainly function naming and global declarations)